### PR TITLE
feat: add mysteries with zero width space

### DIFF
--- a/src/compiler/bytesource.ts
+++ b/src/compiler/bytesource.ts
@@ -42,7 +42,7 @@ function walkNode(roots: Statement[], codeStr: string) {
 }
 
 function padString(len: number) {
-  return len <= 0 ? '' : (' '.repeat(len));
+  return len <= 0 ? '' : ('\u200b'.repeat(len));
 }
 
 function findLineBreaks(codeStr: string) {

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -24,7 +24,7 @@ export function loadBytecode(filename: string) {
   headerUtils.set(byteBuffer, 'flag_hash', getReferenceFlagHash());
 
   const sourceLength = headerUtils.buf2num(headerUtils.get(byteBuffer, 'source_hash'));
-  const dummySource = bytesource.length === sourceLength ? bytesource : ' '.repeat(sourceLength);
+  const dummySource = bytesource.length === sourceLength ? bytesource : '\u200b'.repeat(sourceLength);
   const script = new vm.Script(dummySource, {
     filename: filename,
     cachedData: byteBuffer


### PR DESCRIPTION
Just a trick code with zero width space.

<details>
<summary>Illustrations</summary>

Before, using normal space.
![image](https://user-images.githubusercontent.com/24731539/189826824-14c33f64-09d7-4f90-9c0c-cbd3f923d2f2.png)

After, using zero width space.
![image](https://user-images.githubusercontent.com/24731539/189826943-d4b7c288-2aa4-40fd-a315-56439b76b6c4.png)
</details>